### PR TITLE
Added support for custom repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,9 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 group :rake, :test do
+  #downgrading json gems to build against ruby 1.9.3
+  gem 'json_pure', '<2.0.2'
+  gem 'json', '<2.0.0'
   gem 'rake', '~> 10.4.0',      :require => false
   gem 'rspec', '~> 3.0',        :require => false
   gem 'rspec-core',             :require => false

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ A stock KairosDB 0.9.4-6 without modifications (defaults):
       version => '0.9.4-6',
     }
 
+This module by default installs the package from `github or googlecode` and has the option to
+install from `custom_repo server` for restricted environments
+
+    class { '::kairosdb':
+      version         => '0.9.4-6',
+      package_mirror  => 'custom_repo',
+      custom_url      => 'http://internalmirror.local/kairosdb/kairosdb_%s_all.deb',
+    }
+
 The same thing, but explicitly using a slow development datastore:
 
     class { '::kairosdb':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,7 @@ class kairosdb (
   $manage_package  = true,
   $settings        = {},
   $base_path       = '/opt/kairosdb',
+  $custom_url      = undef,
 ) {
   # Fail fast if we're not using a new Puppet version.
   if versioncmp($::puppetversion, '3.7.0') < 0 {
@@ -39,7 +40,11 @@ class kairosdb (
     validate_re($version, '^(\d+\.\d+\.\d+)(?:-(\d+))?$')
   }
 
-  if $::kairosdb::package_mirror in [ 'github', 'googlecode' ] == false {
+  if $::kairosdb::package_mirror == 'custom_repo' and $::kairosdb::custom_url == undef {
+      fail('Custom repo selected and custom_repo url not defined')
+  }
+
+  if $::kairosdb::package_mirror in [ 'github', 'googlecode','custom_repo' ] == false {
     fail("Unsupported package mirror: ${::kairosdb::package_mirror}!")
   }
 

--- a/manifests/install/debian.pp
+++ b/manifests/install/debian.pp
@@ -21,12 +21,14 @@ class kairosdb::install::debian {
   $version = $::kairosdb::version
   $release = regsubst($version, '^(\d+\.\d+\.\d+)(?:-(\d+))?$', '\1')
 
-  $github_url     = 'https://github.com/kairosdb/kairosdb/releases/download/v%s/kairosdb_%s_all.deb'
-  $googlecode_url = 'https://kairosdb.googlecode.com/files/kairosdb_%s_all.deb'
+  $github_url      = 'https://github.com/kairosdb/kairosdb/releases/download/v%s/kairosdb_%s_all.deb'
+  $googlecode_url  = 'https://kairosdb.googlecode.com/files/kairosdb_%s_all.deb'
+  $localmirror_url = $::kairosdb::custom_url
 
   $source = $::kairosdb::package_mirror ? {
-    'github'     => sprintf($github_url, $release, $version),
-    'googlecode' => sprintf($googlecode_url, $version),
+    'github'      => sprintf($github_url, $release, $version),
+    'googlecode'  => sprintf($googlecode_url, $version),
+    'custom_repo' => sprintf($localmirror_url, $version),
   }
 
   staging::file { "kairosdb_${version}_all.deb":

--- a/manifests/install/default.pp
+++ b/manifests/install/default.pp
@@ -21,12 +21,15 @@ class kairosdb::install::default {
   $version = $::kairosdb::version
   $release = regsubst($version, '^(\d+\.\d+\.\d+)(?:-(\d+))?$', '\1')
 
-  $github_url     = 'https://github.com/kairosdb/kairosdb/releases/download/v%s/kairosdb-%s.tar.gz'
-  $googlecode_url = 'https://kairosdb.googlecode.com/files/kairosdb-%s.tar.gz'
+  $github_url      = 'https://github.com/kairosdb/kairosdb/releases/download/v%s/kairosdb-%s.tar.gz'
+  $googlecode_url  = 'https://kairosdb.googlecode.com/files/kairosdb-%s.tar.gz'
+  $localmirror_url = $::kairosdb::custom_url
+
 
   $source = $::kairosdb::package_mirror ? {
-    'github'     => sprintf($github_url, $release, $version),
-    'googlecode' => sprintf($googlecode_url, $version),
+    'github'      => sprintf($github_url, $release, $version),
+    'googlecode'  => sprintf($googlecode_url, $version),
+    'custom_repo' => sprintf($localmirror_url, $version),
   }
 
   staging::deploy { "kairosdb-${version}.tar.gz":

--- a/manifests/install/redhat.pp
+++ b/manifests/install/redhat.pp
@@ -21,12 +21,15 @@ class kairosdb::install::redhat {
   $version = $::kairosdb::version
   $release = regsubst($version, '^(\d+\.\d+\.\d+)(?:-(\d+))?$', '\1')
 
-  $github_url     = 'https://github.com/kairosdb/kairosdb/releases/download/v%s/kairosdb-%s.rpm'
-  $googlecode_url = 'https://kairosdb.googlecode.com/files/kairosdb-%s.rpm'
+  $github_url      = 'https://github.com/kairosdb/kairosdb/releases/download/v%s/kairosdb-%s.rpm'
+  $googlecode_url  = 'https://kairosdb.googlecode.com/files/kairosdb-%s.rpm'
+  $localmirror_url = $::kairosdb::custom_url
+
 
   $source = $::kairosdb::package_mirror ? {
-    'github'     => sprintf($github_url, $release, $version),
-    'googlecode' => sprintf($googlecode_url, $version),
+    'github'      => sprintf($github_url, $release, $version),
+    'googlecode'  => sprintf($googlecode_url, $version),
+    'custom_repo' => sprintf($localmirror_url, $version),
   }
 
   staging::file { "kairosdb-${version}.rpm":

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -22,8 +22,9 @@ class kairosdb::service {
 
   if $::kairosdb::manage_service {
     service { $::kairosdb::service_name:
-      ensure => $::kairosdb::service_ensure,
-      enable => $::kairosdb::service_enable,
+      ensure    => $::kairosdb::service_ensure,
+      enable    => $::kairosdb::service_enable,
+      hasstatus => false,
     }
   }
 }


### PR DESCRIPTION
Hi jmkeyes

I've added support for custom_repo for the module to be used in environments where they can't go to the internet to download the package.  

has_status is added for the manage_service class as the ubuntu package reports false status with the service kairosdb status command in kairosdb version = '0.9.1-2'

please let me know your thoughts. 
## 

Regards,
Mohan
